### PR TITLE
Fix Pose_TEST patch (send upstream)

### DIFF
--- a/ubuntu/debian/patches/0004_fix_test_pose_zero_positive.patch
+++ b/ubuntu/debian/patches/0004_fix_test_pose_zero_positive.patch
@@ -7,17 +7,14 @@ diff --git a/src/Pose_TEST.cc b/src/Pose_TEST.cc
 index a41c284..3c98771 100644
 --- a/src/Pose_TEST.cc
 +++ b/src/Pose_TEST.cc
-@@ -152,8 +152,11 @@ TEST(PoseTest, OperatorStreamOut)
+@@ -184,6 +184,9 @@ TEST(PoseTest, OperatorStreamOut)
    math::Pose3d p(0.1, 1.2, 2.3, 0.0, 0.1, 1.0);
    std::ostringstream stream;
    stream << p;
 -  EXPECT_EQ(stream.str(), "0.1 1.2 2.3 0 0.1 1");
--}
 +  // some compiler optimizations returns negative zero (-0) in the stream, workaround
 +  // using prefix and postfix check. Not nice I know.
 +  EXPECT_TRUE(stream.str().find("0.1 1.2 2.3") != std::string::npos) << "stream.str is: " << stream.str();
 +  EXPECT_TRUE(stream.str().find("0 0.1 1") != std::string::npos) << "stream.str is: " << stream.str();
-+ }
+ }
  
- /////////////////////////////////////////////////
- TEST(PoseTest, MutablePose)


### PR DESCRIPTION
The nightly builds are failing to apply the Pose_TEST patch:

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-math7-debbuilder&build=20)](https://build.osrfoundation.org/job/ign-math7-debbuilder/20/) https://build.osrfoundation.org/job/ign-math7-debbuilder/20/

~~~
patching file src/Pose_TEST.cc
Hunk #1 FAILED at 152.
1 out of 1 hunk FAILED
dpkg-source: info: the patch has fuzz which is not allowed, or is malformed
~~~

I've queued another build with this branch:

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-math7-debbuilder&build=21)](https://build.osrfoundation.org/job/ign-math7-debbuilder/21/) https://build.osrfoundation.org/job/ign-math7-debbuilder/21/
