### PR TITLE
Depend on libignition-utils1-dev

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -8,6 +8,7 @@ Build-Depends: cmake,
                doxygen,
                libeigen3-dev,
                libignition-cmake2-dev,
+               libignition-utils1-dev,
                python3,
                ruby-ronn,
                swig
@@ -28,6 +29,7 @@ Architecture: any
 Section: libdevel
 Depends: libignition-math7 (= ${binary:Version}),
          libignition-cmake2-dev,
+         libignition-utils1-dev,
          ${misc:Depends}
 Multi-Arch: same
 Description: Ignition Robotics Math Library - Development files


### PR DESCRIPTION
Nightly builds have been failing since https://github.com/ignitionrobotics/ign-math/pull/299 was merged

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-math7-debbuilder&build=325)](https://build.osrfoundation.org/job/ign-math7-debbuilder/325/) https://build.osrfoundation.org/job/ign-math7-debbuilder/325/

~~~
CMake Warning at /usr/share/cmake/ignition-cmake2/cmake2/IgnUtils.cmake:189 (find_package):
  By not providing "Findignition-utils1.cmake" in CMAKE_MODULE_PATH this
  project has asked CMake to find a package configuration file provided by
  "ignition-utils1", but CMake did not find one.

  Could not find a package configuration file provided by "ignition-utils1"
  (requested version 1.0) with any of the following names:

    ignition-utils1Config.cmake
    ignition-utils1-config.cmake

  Add the installation prefix of "ignition-utils1" to CMAKE_PREFIX_PATH or
  set "ignition-utils1_DIR" to a directory containing one of the above files.
  If "ignition-utils1" provides a separate development package or SDK, be
  sure it has been installed.
Call Stack (most recent call first):
  CMakeLists.txt:43 (ign_find_package)
~~~

This should fix it.