### PR TITLE
Remove ruby-ronn from build-deps

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -14,7 +14,6 @@ Build-Depends: cmake,
                python3-distutils,
                python3-pybind11,
                ruby-dev,
-               ruby-ronn,
                swig
 Vcs-Browser: https://github.com/ignitionrobotics/ignition-math
 Vcs-Git: https://github.com/ignition-release/ign_math-release


### PR DESCRIPTION
I was unable to find references to it in the source code. If I remember correctly it was used to generate man pages long ago, did not find references to it on ign-math6 or ign-math4 branches. 